### PR TITLE
fix: asset lastLocation resolves to most recent location record

### DIFF
--- a/src/v1/asset/asset.service.ts
+++ b/src/v1/asset/asset.service.ts
@@ -331,7 +331,7 @@ export class AssetService {
           SELECT al1.asset_id FROM asset_locations al1
           INNER JOIN locations l ON al1.location_id = l.id
           WHERE al1.deleted_at IS NULL AND l.location_uuid IN (:...locationIds) AND al1.created_at = (
-            SELECT MIN(al2.created_at) FROM asset_locations al2 WHERE al2.asset_id = al1.asset_id AND al2.deleted_at IS NULL
+            SELECT MAX(al2.created_at) FROM asset_locations al2 WHERE al2.asset_id = al1.asset_id AND al2.deleted_at IS NULL
           )
         )`,
         { locationIds }
@@ -424,7 +424,7 @@ export class AssetService {
             ? (asset.holderRecords || []).find(h => !h.returnedAt && !h.deletedAt) ?? null
             : null,
           lastLocation: hasLocation
-            ? (asset.locationRecords || []).find(l => !l.deletedAt)?.location ?? null
+            ? (asset.locationRecords || []).filter(l => !l.deletedAt).sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0]?.location ?? null
             : null,
           lastStatus: (asset.statusRecords || []).sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0] ?? null,
           labels: asset.labelRecords || [],
@@ -466,7 +466,7 @@ export class AssetService {
         ? (asset.holderRecords || []).find(h => !h.returnedAt && !h.deletedAt) ?? null
         : null,
       lastLocation: hasLocation
-        ? (asset.locationRecords || []).find(l => !l.deletedAt)?.location ?? null
+        ? (asset.locationRecords || []).filter(l => !l.deletedAt).sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0]?.location ?? null
         : null,
       lastStatus: (asset.statusRecords || []).sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0] ?? null,
       labels: asset.labelRecords || [],
@@ -504,7 +504,7 @@ export class AssetService {
         ? (asset.holderRecords || []).find(h => !h.returnedAt && !h.deletedAt) ?? null
         : null,
       lastLocation: hasLocation
-        ? (asset.locationRecords || []).find(l => !l.deletedAt)?.location ?? null
+        ? (asset.locationRecords || []).filter(l => !l.deletedAt).sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0]?.location ?? null
         : null,
       lastStatus: (asset.statusRecords || []).sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0] ?? null,
       labels: asset.labelRecords || [],


### PR DESCRIPTION
## Summary

- `lastLocation` sebelumnya menggunakan `.find()` yang mengambil record pertama yang ditemukan, bukan yang terbaru
- Filter `locationId` pada query pagination menggunakan `MIN(created_at)` sehingga match ke lokasi pertama, bukan lokasi terakhir
- Kedua masalah sudah diperbaiki agar selalu mengambil data lokasi terbaru berdasarkan `created_at`

## Changes

- `asset.service.ts` — ganti `.find(l => !l.deletedAt)` → `.filter().sort(desc by createdAt)[0]` di 3 tempat (`paginate`, `findOne`, `findOneByCode`)
- `asset.service.ts` — ganti `MIN(al2.created_at)` → `MAX(al2.created_at)` pada subquery filter `locationId`

## Test plan

- [ ] Buat asset dengan beberapa riwayat lokasi, pastikan `lastLocation` menampilkan lokasi yang paling terakhir diinput
- [ ] Filter by `locationId` memastikan asset yang muncul adalah yang lokasi terakhirnya sesuai, bukan lokasi pertama

🤖 Generated with [Claude Code](https://claude.com/claude-code)