### PR TITLE
feat: add Gemini scan-barcode endpoint and fix CORS + image validator

### DIFF
--- a/src/common/validators/image-upload.validator.ts
+++ b/src/common/validators/image-upload.validator.ts
@@ -13,7 +13,8 @@ export const ImageUploadValidator = new ParseFilePipeBuilder()
   )
   .addValidator(
     new FileTypeValidator({
-      fileType: /(jpg|jpeg|png)$/,
+      fileType: /image\/(jpeg|png)$/,
+      skipMagicNumbersValidation: true,
     }),
   )
   .build({

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,22 +13,22 @@ async function bootstrap() {
   app.set('trust proxy', true);
   app.useGlobalPipes(customValidationPipe());
 
-  app.enableCors({
-    origin: '*',
-    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'x-api-key'],
-    credentials: false,
-  });
-
   // app.enableCors({
-  //   origin: [
-  //     'http://localhost:3000',
-  //     'https://a.nusa.id'
-  //   ],
+  //   origin: '*',
   //   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
   //   allowedHeaders: ['Content-Type', 'Authorization', 'x-api-key'],
-  //   credentials: true,
+  //   credentials: false,
   // });
+
+  app.enableCors({
+    origin: [
+      'http://localhost:3000',
+      'https://a.nusa.id'
+    ],
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'x-api-key'],
+    credentials: true,
+  });
 
   app.useGlobalInterceptors(new ResponseInterceptor());
 

--- a/src/v1/gemini/gemini.controller.ts
+++ b/src/v1/gemini/gemini.controller.ts
@@ -1,0 +1,30 @@
+import {
+  Controller,
+  Post,
+  UploadedFile,
+  UseInterceptors,
+  BadRequestException,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { GeminiService } from './gemini.service';
+import { ImageUploadValidator } from '../../common/validators/image-upload.validator';
+import { ApiResponse } from '../../common/utils/ApiResponse';
+import { Public } from '../../common/decorator/public.decorator';
+
+@Controller()
+export class GeminiController {
+  constructor(private readonly geminiService: GeminiService) {}
+
+  @Post('scan-barcode')
+  @Public()
+  @UseInterceptors(FileInterceptor('image'))
+  async scanBarcode(
+    @UploadedFile(ImageUploadValidator) image: Express.Multer.File,
+  ) {
+    if (!image) {
+      throw new BadRequestException('Image file is required');
+    }
+    const result = await this.geminiService.parseImage(image);
+    return new ApiResponse('Barcode scanned successfully', result);
+  }
+}

--- a/src/v1/gemini/gemini.module.ts
+++ b/src/v1/gemini/gemini.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { GeminiService } from './gemini.service';
+import { GeminiController } from './gemini.controller';
 
 @Module({
+  controllers: [GeminiController],
   providers: [GeminiService],
-  exports: [GeminiService]
+  exports: [GeminiService],
 })
 export class GeminiModule {}

--- a/src/v1/v1.module.ts
+++ b/src/v1/v1.module.ts
@@ -1,4 +1,4 @@
-import { Controller, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { CategoryModule } from './category/category.module';
 import { UserModule } from './user/user.module';
 import { APP_GUARD, RouterModule } from '@nestjs/core';
@@ -112,7 +112,11 @@ import { AssetStatusModule } from './asset-status/asset-status.module';
           {
             path: '/user/my-assets',
             module: UserModule
-          }
+          },
+          {
+            path: '/gemini',
+            module: GeminiModule,
+          },
         ],
       },
     ]),


### PR DESCRIPTION
## Summary

- Add `GeminiController` with `POST /v1/gemini/scan-barcode` endpoint untuk scan barcode via image menggunakan Gemini AI
- Register controller ke `GeminiModule` dan tambah route `/gemini` di `V1Module`
- Perbaiki konfigurasi CORS: dari wildcard `*` ke origin spesifik (`localhost:3000`, `a.nusa.id`) dengan `credentials: true`
- Fix regex validator image upload dari `/(jpg|jpeg|png)$/` ke `/image\/(jpeg|png)$/` (MIME type) dan tambah `skipMagicNumbersValidation: true`

## Test plan

- [ ] `POST /v1/gemini/scan-barcode` dengan file image `.jpg` / `.png` — pastikan response sukses
- [ ] `POST /v1/gemini/scan-barcode` tanpa file — pastikan response `400 Bad Request`
- [ ] Request dari `http://localhost:3000` dan `https://a.nusa.id` — pastikan CORS tidak diblok
- [ ] Request dari origin lain — pastikan CORS diblok