### PR TITLE
feat: add ResponseAssetStatusDto, create ACTIVE status on import, fix CORS

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,22 +13,22 @@ async function bootstrap() {
   app.set('trust proxy', true);
   app.useGlobalPipes(customValidationPipe());
 
-  app.enableCors({
-    origin: '*',
-    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'x-api-key'],
-    credentials: false,
-  });
-
   // app.enableCors({
-  //   origin: [
-  //     'http://localhost:3000',
-  //     'https://a.nusa.id'
-  //   ],
+  //   origin: '*',
   //   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
   //   allowedHeaders: ['Content-Type', 'Authorization', 'x-api-key'],
-  //   credentials: true,
+  //   credentials: false,
   // });
+
+  app.enableCors({
+    origin: [
+      'http://localhost:3000',
+      'https://a.nusa.id'
+    ],
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'x-api-key'],
+    credentials: true,
+  });
 
   app.useGlobalInterceptors(new ResponseInterceptor());
 

--- a/src/v1/asset-status/asset-status.controller.ts
+++ b/src/v1/asset-status/asset-status.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Post, Body, Param, UseGuards, ParseUUIDPipe, Query, DefaultValuePipe, ParseIntPipe } from '@nestjs/common';
 import { AssetStatusService } from './asset-status.service';
 import { CreateAssetStatusDto } from './dto/create-asset-status.dto';
-import { ResponseAssetStatusDto } from '../asset/dto/response-asset.dto';
+import { ResponseAssetStatusDto } from './dto/response-asset-status.dto';
 import { Serialize } from '../../common/interceptor/serialize.interceptor';
 import { User } from '../../common/decorator/auth-user.decorator';
 import { User as UserEntity } from '../user/entities/user.entity';

--- a/src/v1/asset-status/dto/response-asset-status.dto.ts
+++ b/src/v1/asset-status/dto/response-asset-status.dto.ts
@@ -1,0 +1,32 @@
+import { Expose, Type } from 'class-transformer';
+import { AssetStatusType } from '../enum/asset-status.enum';
+import { ResponseUserDto } from '../../user/dto/response-user.dto';
+
+export class ResponseAssetStatusDto {
+  @Expose({ name: 'assetStatusUuid' })
+  id: string;
+
+  @Expose()
+  type: AssetStatusType;
+
+  @Expose()
+  note: string | null;
+
+  @Expose()
+  createdAt: Date;
+
+  @Expose()
+  @Type(() => ResponseUserSimpleDto)
+  user: ResponseUserSimpleDto | null;
+}
+
+export class ResponseUserSimpleDto {
+  @Expose()
+  name: string;
+
+  @Expose()
+  employeeId: string;
+
+  @Expose()
+  avatar: string;
+}

--- a/src/v1/asset/asset-utils.service.ts
+++ b/src/v1/asset/asset-utils.service.ts
@@ -10,6 +10,8 @@ import { AssetHolder } from '../asset-holder/entities/asset-holder.entity';
 import { AssetLocation } from '../asset-location/entities/asset-location.entity';
 import { Location } from '../location/entities/location.entity';
 import { AssetLabel } from '../asset-label/entities/asset-label.entity';
+import { AssetStatus } from '../asset-status/entities/asset-status.entity';
+import { AssetStatusType } from '../asset-status/enum/asset-status.enum';
 
 @Injectable()
 export class AssetUtilsService {
@@ -27,7 +29,9 @@ export class AssetUtilsService {
         @InjectRepository(Location)
         private readonly locationRepository: Repository<Location>,
         @InjectRepository(AssetLabel)
-        private readonly assetLabelRepository: Repository<AssetLabel>
+        private readonly assetLabelRepository: Repository<AssetLabel>,
+        @InjectRepository(AssetStatus)
+        private readonly assetStatusRepository: Repository<AssetStatus>,
     ) {}
     /**
      * Retrieves all assets that match the given filters for Excel export.
@@ -410,6 +414,14 @@ export class AssetUtilsService {
         });
 
         const savedAsset = await this.assetRepository.save(asset);
+
+        await this.assetStatusRepository.save(
+            this.assetStatusRepository.create({
+                assetId: savedAsset.id,
+                type: AssetStatusType.ACTIVE,
+                userId: userId ?? null,
+            }),
+        );
 
         if (holderEmployeeId) {
             const holder = this.assetHolderRepository.create({


### PR DESCRIPTION
## Summary

- Buat `ResponseAssetStatusDto` dengan field `type`, `note`, `user` (via `ResponseUserSimpleDto`), dan `createdAt`
- Fix import path `ResponseAssetStatusDto` di `asset-status.controller.ts` — sebelumnya salah merujuk ke `response-asset.dto`
- Tambah pembuatan record status `ACTIVE` saat import asset via Excel (`importAssets` di `asset-utils.service.ts`)
- Perbaiki CORS: dari wildcard `*` ke origin spesifik (`localhost:3000`, `a.nusa.id`) dengan `credentials: true`

## Test plan

- [ ] Import asset via Excel — pastikan record `asset_statuses` dengan type `active` terbuat
- [ ] `GET /v1/asset-status/:assetId` — pastikan response sesuai `ResponseAssetStatusDto`
- [ ] Request dari `http://localhost:3000` dan `https://a.nusa.id` — pastikan tidak diblok CORS
- [ ] Request dari origin lain — pastikan diblok CORS