### PR TITLE
feat: asset-status attachment and isTransferred support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,22 +13,22 @@ async function bootstrap() {
   app.set('trust proxy', true);
   app.useGlobalPipes(customValidationPipe());
 
-  app.enableCors({
-    origin: '*',
-    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'x-api-key'],
-    credentials: false,
-  });
-
   // app.enableCors({
-  //   origin: [
-  //     'http://localhost:3000',
-  //     'https://a.nusa.id'
-  //   ],
+  //   origin: '*',
   //   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
   //   allowedHeaders: ['Content-Type', 'Authorization', 'x-api-key'],
-  //   credentials: true,
+  //   credentials: false,
   // });
+
+  app.enableCors({
+    origin: [
+      'http://localhost:3000',
+      'https://a.nusa.id'
+    ],
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'x-api-key'],
+    credentials: true,
+  });
 
   app.useGlobalInterceptors(new ResponseInterceptor());
 

--- a/src/v1/asset-status/asset-status.controller.ts
+++ b/src/v1/asset-status/asset-status.controller.ts
@@ -1,8 +1,11 @@
-import { Controller, Get, Post, Body, Param, UseGuards, ParseUUIDPipe, Query, DefaultValuePipe, ParseIntPipe } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, ParseUUIDPipe, Query, DefaultValuePipe, ParseIntPipe, UseInterceptors, UploadedFiles } from '@nestjs/common';
+import { FilesInterceptor } from '@nestjs/platform-express';
 import { AssetStatusService } from './asset-status.service';
 import { CreateAssetStatusDto } from './dto/create-asset-status.dto';
 import { ResponseAssetStatusDto } from './dto/response-asset-status.dto';
 import { Serialize } from '../../common/interceptor/serialize.interceptor';
+import { SerializeV2Interceptor } from '../../common/interceptor/serialize-v2.interceptor';
+import { PreSignedUrl } from '../../common/decorator/presigned-url.decorator';
 import { User } from '../../common/decorator/auth-user.decorator';
 import { User as UserEntity } from '../user/entities/user.entity';
 import { ApiResponse } from '../../common/utils/ApiResponse';
@@ -12,12 +15,14 @@ export class AssetStatusController {
   constructor(private readonly assetStatusService: AssetStatusService) {}
 
   @Post()
-  @Serialize(ResponseAssetStatusDto)
+  @UseInterceptors(FilesInterceptor('attachments', 3))
   async create(
     @Param('assetUuid', new ParseUUIDPipe()) assetUuid: string,
-    @Body() createAssetStatusDto: CreateAssetStatusDto,
+    @Body() body: any,
     @User() user: UserEntity,
+    @UploadedFiles() attachments: Express.Multer.File[],
   ) {
+    const createAssetStatusDto: CreateAssetStatusDto = { ...body, attachments };
     return new ApiResponse(
       'Asset status updated successfully',
       await this.assetStatusService.create(user.id, assetUuid, createAssetStatusDto),
@@ -25,7 +30,11 @@ export class AssetStatusController {
   }
 
   @Get()
+  @PreSignedUrl([
+    { originalKey: 'attachmentPaths', urlKey: 'attachmentUrls' }
+  ])
   @Serialize(ResponseAssetStatusDto)
+  @UseInterceptors(SerializeV2Interceptor)
   async findAll(
     @Param('assetUuid', new ParseUUIDPipe()) assetUuid: string,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number = 1,

--- a/src/v1/asset-status/asset-status.module.ts
+++ b/src/v1/asset-status/asset-status.module.ts
@@ -6,11 +6,13 @@ import { AssetStatus } from './entities/asset-status.entity';
 import { Asset } from '../asset/entities/asset.entity';
 import { AssetLogModule } from '../asset-log/asset-log.module';
 import { User } from '../user/entities/user.entity';
+import { StorageModule } from '../../storage/storage.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([AssetStatus, Asset, User]),
     AssetLogModule,
+    StorageModule,
   ],
   controllers: [AssetStatusController],
   providers: [AssetStatusService],

--- a/src/v1/asset-status/asset-status.service.ts
+++ b/src/v1/asset-status/asset-status.service.ts
@@ -7,6 +7,7 @@ import { Asset } from '../asset/entities/asset.entity';
 import { IPaginationOptions, paginate, Pagination } from 'nestjs-typeorm-paginate';
 import { LogAsset } from '../asset-log/decorator/log-asset.decorator';
 import { AssetLogType } from '../asset-log/enum/asset-log.enum';
+import { StorageService } from '../../storage/storage.service';
 
 @Injectable()
 export class AssetStatusService {
@@ -15,6 +16,7 @@ export class AssetStatusService {
     private readonly assetStatusRepository: Repository<AssetStatus>,
     @InjectRepository(Asset)
     private readonly assetRepository: Repository<Asset>,
+    private readonly storageService: StorageService,
   ) {}
 
   @LogAsset(async (args, result, ctx) => {
@@ -30,11 +32,23 @@ export class AssetStatusService {
       where: { assetUuid },
     });
 
+    const uploadedPaths: string[] = [];
+    if (createAssetStatusDto.attachments?.length) {
+      const results = await Promise.all(
+        createAssetStatusDto.attachments.map(file =>
+          this.storageService.uploadFile('asset-status', file),
+        ),
+      );
+      uploadedPaths.push(...results.filter((p): p is string => !!p));
+    }
+
     const status = this.assetStatusRepository.create({
       assetId: asset.id,
       userId,
       type: createAssetStatusDto.type,
       note: createAssetStatusDto.note,
+      isTransferred: createAssetStatusDto.isTransferred ?? false,
+      attachmentPaths: uploadedPaths,
     });
 
     return this.assetStatusRepository.save(status);

--- a/src/v1/asset-status/dto/create-asset-status.dto.ts
+++ b/src/v1/asset-status/dto/create-asset-status.dto.ts
@@ -1,4 +1,5 @@
-import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsEnum, IsOptional, IsString } from 'class-validator';
 import { AssetStatusType } from '../enum/asset-status.enum';
 
 export class CreateAssetStatusDto {
@@ -8,4 +9,11 @@ export class CreateAssetStatusDto {
     @IsOptional()
     @IsString()
     note?: string;
+
+    @IsOptional()
+    @IsBoolean()
+    @Transform(({ value }) => value === 'true' || value === true)
+    isTransferred?: boolean;
+
+    attachments?: Express.Multer.File[];
 }

--- a/src/v1/asset-status/dto/response-asset-status.dto.ts
+++ b/src/v1/asset-status/dto/response-asset-status.dto.ts
@@ -13,6 +13,15 @@ export class ResponseAssetStatusDto {
   note: string | null;
 
   @Expose()
+  isTransferred: boolean;
+
+  @Expose()
+  attachmentPaths: string[];
+
+  @Expose()
+  attachmentUrls: string[];
+
+  @Expose()
   createdAt: Date;
 
   @Expose()

--- a/src/v1/asset-status/entities/asset-status.entity.ts
+++ b/src/v1/asset-status/entities/asset-status.entity.ts
@@ -24,6 +24,12 @@ export class AssetStatus {
     @Column({ name: 'type', type: 'enum', enum: AssetStatusType, default: AssetStatusType.ACTIVE })
     type: AssetStatusType;
 
+    @Column({ name: 'is_transferred', type: 'boolean', default: false })
+    isTransferred: boolean;
+
+    @Column({ name:'attachment_paths', type: 'json', nullable: true})
+    attachmentPaths: string[];
+
     @CreateDateColumn({ name: 'created_at' })
     createdAt: Date;
 

--- a/src/v1/asset-status/enum/asset-status.enum.ts
+++ b/src/v1/asset-status/enum/asset-status.enum.ts
@@ -1,6 +1,4 @@
 export enum AssetStatusType {
     ACTIVE = 'active',
-    SOLD = 'sold',
-    GRANTED = 'granted',
-    DISPOSED = 'disposed',
+    INACTIVE = 'inactive',
 }


### PR DESCRIPTION
## Summary
- Add `isTransferred` (boolean) and `attachmentPaths` (json) columns to `AssetStatus` entity
- Support multi-file upload (max 3) on `POST` asset-status via `FilesInterceptor`
- Files uploaded to storage under `asset-status/` folder, paths saved to `attachmentPaths`
- `GET` list generates pre-signed URLs via `@PreSignedUrl` decorator (`attachmentUrls`)
- Update enum `AssetStatusType`: replaced `SOLD`, `GRANTED`, `DISPOSED` → `INACTIVE`
- Restrict CORS to specific origins (`localhost:3000`, `a.nusa.id`) with `credentials: true`

## Commits
1. `feat`: add `isTransferred` and `attachmentPaths` columns to entity + enum update
2. `feat`: add `isTransferred` and attachment fields to DTOs
3. `feat`: inject `StorageService`, handle file upload in service + import `StorageModule`
4. `feat`: add `FilesInterceptor` and `PreSignedUrl` to controller
5. `fix`: restrict CORS to specific allowed origins

## Test plan
- [ ] POST asset-status tanpa attachment — berhasil, `attachmentPaths: []`
- [ ] POST asset-status dengan 1–3 file — file terupload, path tersimpan
- [ ] POST dengan `isTransferred: true` — tersimpan benar di DB
- [ ] GET asset-status — `attachmentUrls` berisi signed URL yang valid
- [ ] Pastikan migration untuk kolom `is_transferred` dan `attachment_paths` sudah dijalankan

🤖 Generated with [Claude Code](https://claude.com/claude-code)