### PR TITLE
fix: make hasHolder filter support true/false/undefined (3-state)

### DIFF
--- a/src/v1/asset/asset-utils.service.ts
+++ b/src/v1/asset/asset-utils.service.ts
@@ -164,6 +164,16 @@ export class AssetUtilsService {
                 .getQuery();
               return 'asset.id IN ' + subQuery;
             });
+        } else if (hasHolder === false) {
+            qb.andWhere(qb2 => {
+              const subQuery = qb2.subQuery()
+                .select('ah.asset_id')
+                .from('asset_holders', 'ah')
+                .where('ah.returned_at IS NULL')
+                .andWhere('ah.deleted_at IS NULL')
+                .getQuery();
+              return 'asset.id NOT IN ' + subQuery;
+            });
         }
 
         if (locationId) {

--- a/src/v1/asset/asset.controller.ts
+++ b/src/v1/asset/asset.controller.ts
@@ -98,7 +98,7 @@ export class AssetController {
     @Query('branchId') branchId?: string,
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
-    @Query('hasHolder', new DefaultValuePipe(false), ParseBoolPipe) hasHolder?: boolean,
+    @Query('hasHolder', new ParseBoolPipe({ optional: true })) hasHolder?: boolean,
     @Query('order', new DefaultValuePipe('DESC')) order?: string,
     @Query('sort', new DefaultValuePipe('createdAt')) sort?: string,
     @Query('labels') labels?: string,
@@ -137,7 +137,7 @@ export class AssetController {
     @Query('branchId') branchId?: string,
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
-    @Query('hasHolder', new DefaultValuePipe(false), ParseBoolPipe) hasHolder?: boolean,
+    @Query('hasHolder', new ParseBoolPipe({ optional: true })) hasHolder?: boolean,
     @Query('search', new DefaultValuePipe('')) search?: string,
     @Query('labels') labels?: string,
   ) {

--- a/src/v1/asset/asset.service.ts
+++ b/src/v1/asset/asset.service.ts
@@ -322,6 +322,10 @@ export class AssetService {
       queryBuilder.andWhere(
         `asset.id IN (SELECT ah.asset_id FROM asset_holders ah WHERE ah.returned_at IS NULL AND ah.deleted_at IS NULL)`
       );
+    } else if (hasHolder === false) {
+      queryBuilder.andWhere(
+        `asset.id NOT IN (SELECT ah.asset_id FROM asset_holders ah WHERE ah.returned_at IS NULL AND ah.deleted_at IS NULL)`
+      );
     }
 
     if (locationId) {


### PR DESCRIPTION
## Changes

Mengubah filter `hasHolder` dari boolean (selalu default `false`) menjadi 3-state: `true`, `false`, atau `undefined`.

### Behavior

| Nilai | Hasil |
|---|---|
| `hasHolder=true` | Hanya asset yang **punya** active holder |
| `hasHolder=false` | Hanya asset yang **tidak punya** active holder |
| Tidak dikirim | Semua asset (tanpa filter holder) |

### Files Changed

- `asset.controller.ts` — Remove `DefaultValuePipe(false)`, gunakan `ParseBoolPipe({ optional: true })` di endpoint `findAll` dan `exportXLS`
- `asset.service.ts` — Tambah `else if (hasHolder === false)` dengan `NOT IN` subquery
- `asset-utils.service.ts` — Tambah `else if (hasHolder === false)` dengan `NOT IN` subquery di export service